### PR TITLE
Add detection helper and new UI controls

### DIFF
--- a/app/src/main/java/com/dunghn2201/cameradetectionobject/Detector.kt
+++ b/app/src/main/java/com/dunghn2201/cameradetectionobject/Detector.kt
@@ -1,0 +1,97 @@
+package com.dunghn2201.cameradetectionobject
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.RectF
+import com.dunghn2201.cameradetectionobject.ml.SsdMobilenetV11Metadata1
+import org.tensorflow.lite.support.common.FileUtil
+import org.tensorflow.lite.support.image.ImageProcessor
+import org.tensorflow.lite.support.image.TensorImage
+import org.tensorflow.lite.support.image.ops.ResizeOp
+
+/**
+ * Helper class that encapsulates object detection logic using the bundled
+ * TensorFlow Lite model. The [detect] function runs inference on a bitmap and
+ * returns a new bitmap with bounding boxes and labels drawn over it.
+ */
+class Detector(context: Context) {
+
+    private val colors = listOf(
+        Color.BLUE,
+        Color.GREEN,
+        Color.RED,
+        Color.CYAN,
+        Color.GRAY,
+        Color.BLACK,
+        Color.DKGRAY,
+        Color.MAGENTA,
+        Color.YELLOW,
+        Color.RED
+    )
+
+    private val labels: List<String> = FileUtil.loadLabels(context, "labels.txt")
+    private val paint = Paint()
+    private val imageProcessor: ImageProcessor =
+        ImageProcessor.Builder()
+            .add(ResizeOp(300, 300, ResizeOp.ResizeMethod.BILINEAR))
+            .build()
+    private val model: SsdMobilenetV11Metadata1 =
+        SsdMobilenetV11Metadata1.newInstance(context)
+
+    /**
+     * Runs object detection on [bitmap] and draws results above the image.
+     * @param threshold Minimum confidence score required to display a detection.
+     */
+    fun detect(bitmap: Bitmap, threshold: Float): Bitmap {
+        var image = TensorImage.fromBitmap(bitmap)
+        image = imageProcessor.process(image)
+
+        val outputs = model.process(image)
+        val locations = outputs.locationsAsTensorBuffer.floatArray
+        val classes = outputs.classesAsTensorBuffer.floatArray
+        val scores = outputs.scoresAsTensorBuffer.floatArray
+
+        val mutable = bitmap.copy(Bitmap.Config.ARGB_8888, true)
+        val canvas = Canvas(mutable)
+
+        val h = mutable.height
+        val w = mutable.width
+
+        paint.textSize = h / 15f
+        paint.strokeWidth = h / 85f
+
+        scores.forEachIndexed { index, score ->
+            val offset = index * 4
+            if (score > threshold) {
+                paint.color = colors[index % colors.size]
+                paint.style = Paint.Style.STROKE
+                canvas.drawRect(
+                    RectF(
+                        locations[offset + 1] * w,
+                        locations[offset] * h,
+                        locations[offset + 3] * w,
+                        locations[offset + 2] * h
+                    ), paint
+                )
+                paint.style = Paint.Style.FILL
+                canvas.drawText(
+                    labels[classes[index].toInt()] + " " + "%.2f".format(score),
+                    locations[offset + 1] * w,
+                    locations[offset] * h,
+                    paint
+                )
+            }
+        }
+
+        return mutable
+    }
+
+    /** Releases the underlying ML model. */
+    fun close() {
+        model.close()
+    }
+}
+

--- a/app/src/main/java/com/dunghn2201/cameradetectionobject/MainActivity.kt
+++ b/app/src/main/java/com/dunghn2201/cameradetectionobject/MainActivity.kt
@@ -1,171 +1,105 @@
 package com.dunghn2201.cameradetectionobject
 
 import android.Manifest
-import android.annotation.SuppressLint
 import android.content.Context
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
-import android.graphics.Canvas
-import android.graphics.Color
-import android.graphics.Paint
-import android.graphics.RectF
 import android.graphics.SurfaceTexture
 import android.hardware.camera2.CameraCaptureSession
 import android.hardware.camera2.CameraDevice
 import android.hardware.camera2.CameraManager
-import android.media.Image
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import android.os.FileUtils
 import android.os.Handler
 import android.os.HandlerThread
 import android.view.Surface
 import android.view.TextureView
+import android.widget.SeekBar
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import com.dunghn2201.cameradetectionobject.databinding.ActivityMainBinding
-import com.dunghn2201.cameradetectionobject.ml.SsdMobilenetV11Metadata1
-import org.tensorflow.lite.support.common.FileUtil
-import org.tensorflow.lite.support.image.ImageProcessor
-import org.tensorflow.lite.support.image.TensorImage
-import org.tensorflow.lite.support.image.ops.ResizeOp
 
 class MainActivity : AppCompatActivity() {
 
-    val colors = listOf(
-        Color.BLUE,
-        Color.GREEN,
-        Color.RED,
-        Color.CYAN,
-        Color.GRAY,
-        Color.BLACK,
-        Color.DKGRAY,
-        Color.MAGENTA,
-        Color.YELLOW,
-        Color.RED
-    )
-    lateinit var labels: List<String>
-    val paint = Paint()
-    lateinit var imageProcessor: ImageProcessor
-    lateinit var bitmap: Bitmap
-    lateinit var cameraDevice: CameraDevice
-    lateinit var handler: Handler
-    lateinit var cameraManager: CameraManager
-    lateinit var model: SsdMobilenetV11Metadata1
-    lateinit var binding: ActivityMainBinding
+    private lateinit var detector: Detector
+    private lateinit var bitmap: Bitmap
+    private lateinit var cameraDevice: CameraDevice
+    private lateinit var handler: Handler
+    private lateinit var cameraManager: CameraManager
+    private lateinit var binding: ActivityMainBinding
+
+    private var isDetectionEnabled = true
+    private var detectionThreshold = 0.5f
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
+        detector = Detector(this)
         getPermission()
-        model = SsdMobilenetV11Metadata1.newInstance(this@MainActivity)
-        labels = FileUtil.loadLabels(this, "labels.txt")
-        imageProcessor =
-            ImageProcessor.Builder().add(ResizeOp(300, 300, ResizeOp.ResizeMethod.BILINEAR)).build()
+
         val handlerThread = HandlerThread("cameraThread")
         handlerThread.start()
         handler = Handler(handlerThread.looper)
         cameraManager = getSystemService(Context.CAMERA_SERVICE) as CameraManager
-        binding.textTureView.surfaceTextureListener =
-            object : TextureView.SurfaceTextureListener {
-                override fun onSurfaceTextureAvailable(
-                    surface: SurfaceTexture,
-                    width: Int,
-                    height: Int
-                ) {
-                    openCamera()
-                }
 
-                override fun onSurfaceTextureSizeChanged(
-                    surface: SurfaceTexture,
-                    width: Int,
-                    height: Int
-                ) {
+        binding.detectToggleButton.setOnClickListener {
+            isDetectionEnabled = !isDetectionEnabled
+            binding.detectToggleButton.text = if (isDetectionEnabled) "Stop" else "Start"
+        }
 
-                }
-
-                override fun onSurfaceTextureDestroyed(surface: SurfaceTexture): Boolean {
-                    return false
-                }
-
-                override fun onSurfaceTextureUpdated(surface: SurfaceTexture) {
-                    bitmap = binding.textTureView.bitmap!!
-
-                    // Creates inputs for reference.
-                    var image = TensorImage.fromBitmap(bitmap)
-                    image = imageProcessor.process(image)
-                    // Runs model inference and gets result.
-                    val outputs = model.process(image)
-                    val locations = outputs.locationsAsTensorBuffer.floatArray
-                    val classes = outputs.classesAsTensorBuffer.floatArray
-                    val scores = outputs.scoresAsTensorBuffer.floatArray
-                    val numberOfDetections = outputs.numberOfDetectionsAsTensorBuffer.floatArray
-
-                    val mutable = bitmap.copy(Bitmap.Config.ARGB_8888, true)
-                    val canvas = Canvas(mutable)
-
-                    val h = mutable.height
-                    val w = mutable.width
-
-                    paint.textSize = h / 15f
-                    paint.strokeWidth = h / 85f
-                    var x = 0
-                    scores.forEachIndexed { index, fl ->
-                        x = index
-                        x *= 4
-                        if (fl > 0.5) {
-                            paint.setColor(colors.get(index))
-                            paint.style = Paint.Style.STROKE
-                            canvas.drawRect(
-                                RectF(
-                                    locations.get(x + 1) * x,
-                                    locations.get(x) * h,
-                                    locations.get(x + 3) * w,
-                                    locations.get(x + 2) * h
-                                ), paint
-                            )
-                            paint.style = Paint.Style.FILL
-                            canvas.drawText(
-                                labels.get(
-                                    classes.get(index).toInt()
-                                ) + " " + fl.toString(),
-                                locations.get(x + 1) * w,
-                                locations.get(x) * h,
-                                paint
-                            )
-                        }
-                    }
-                    binding.imageView.setImageBitmap(mutable)
-
-                }
-
+        binding.thresholdSeekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
+            override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
+                detectionThreshold = progress / 100f
+                binding.thresholdTextView.text = "Threshold: " + "%.2f".format(detectionThreshold)
             }
+
+            override fun onStartTrackingTouch(seekBar: SeekBar?) {}
+            override fun onStopTrackingTouch(seekBar: SeekBar?) {}
+        })
+
+        binding.textureView.surfaceTextureListener = object : TextureView.SurfaceTextureListener {
+            override fun onSurfaceTextureAvailable(surface: SurfaceTexture, width: Int, height: Int) {
+                openCamera()
+            }
+
+            override fun onSurfaceTextureSizeChanged(surface: SurfaceTexture, width: Int, height: Int) {}
+
+            override fun onSurfaceTextureDestroyed(surface: SurfaceTexture): Boolean {
+                return false
+            }
+
+            override fun onSurfaceTextureUpdated(surface: SurfaceTexture) {
+                bitmap = binding.textureView.bitmap!!
+                val result = if (isDetectionEnabled) {
+                    detector.detect(bitmap, detectionThreshold)
+                } else {
+                    bitmap
+                }
+                binding.imageView.setImageBitmap(result)
+            }
+        }
     }
 
     override fun onDestroy() {
         super.onDestroy()
-        // Releases model resources if no longer used.
-        model.close()
-
+        detector.close()
     }
 
     private fun openCamera() {
-        if (ActivityCompat.checkSelfPermission(
-                this,
-                Manifest.permission.CAMERA
-            ) != PackageManager.PERMISSION_GRANTED
-        ) {
+        if (ActivityCompat.checkSelfPermission(this, Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
             getPermission()
             return
         }
         cameraManager.openCamera(
-            cameraManager.cameraIdList.first(), object : CameraDevice.StateCallback() {
+            cameraManager.cameraIdList.first(),
+            object : CameraDevice.StateCallback() {
                 override fun onOpened(camera: CameraDevice) {
                     cameraDevice = camera
-                    val surfaceTexture = binding.textTureView.surfaceTexture
+                    val surfaceTexture = binding.textureView.surfaceTexture
                     val surface = Surface(surfaceTexture)
-                    val captureRequest =
-                        cameraDevice.createCaptureRequest(CameraDevice.TEMPLATE_PREVIEW)
+                    val captureRequest = cameraDevice.createCaptureRequest(CameraDevice.TEMPLATE_PREVIEW)
                     captureRequest.addTarget(surface)
                     cameraDevice.createCaptureSession(
                         listOf(surface),
@@ -174,41 +108,30 @@ class MainActivity : AppCompatActivity() {
                                 session.setRepeatingRequest(captureRequest.build(), null, null)
                             }
 
-                            override fun onConfigureFailed(session: CameraCaptureSession) {
-                            }
+                            override fun onConfigureFailed(session: CameraCaptureSession) {}
                         },
                         handler
                     )
                 }
 
-                override fun onDisconnected(camera: CameraDevice) {
-                }
-
-                override fun onError(camera: CameraDevice, error: Int) {
-                }
+                override fun onDisconnected(camera: CameraDevice) {}
+                override fun onError(camera: CameraDevice, error: Int) {}
             },
             handler
         )
     }
 
     private fun getPermission() {
-        if (ContextCompat.checkSelfPermission(
-                this,
-                android.Manifest.permission.CAMERA
-            ) != PackageManager.PERMISSION_GRANTED
-        ) {
-            requestPermissions(arrayOf(android.Manifest.permission.CAMERA), 101)
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
+            requestPermissions(arrayOf(Manifest.permission.CAMERA), 101)
         }
     }
 
-    override fun onRequestPermissionsResult(
-        requestCode: Int,
-        permissions: Array<out String>,
-        grantResults: IntArray
-    ) {
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        if (grantResults.first() != PackageManager.PERMISSION_GRANTED) {
+        if (grantResults.firstOrNull() != PackageManager.PERMISSION_GRANTED) {
             getPermission()
         }
     }
 }
+

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,18 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
     <TextureView
-        android:id="@+id/textTureView"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:id="@+id/textureView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
 
     <ImageView
         android:id="@+id/imageView"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="#000" />
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#00000000"
+        app:layout_constraintTop_toTopOf="@id/textureView"
+        app:layout_constraintBottom_toBottomOf="@id/textureView"
+        app:layout_constraintStart_toStartOf="@id/textureView"
+        app:layout_constraintEnd_toEndOf="@id/textureView" />
+
+    <Button
+        android:id="@+id/detectToggleButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Stop"
+        android:layout_margin="16dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
+    <SeekBar
+        android:id="@+id/thresholdSeekBar"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:max="100"
+        android:progress="50"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        app:layout_constraintStart_toEndOf="@id/detectToggleButton"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
+    <TextView
+        android:id="@+id/thresholdTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Threshold: 0.5"
+        android:layout_marginStart="16dp"
+        android:layout_marginBottom="8dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/detectToggleButton" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- refactor detection logic into a new `Detector` helper
- add button and seek bar UI controls for starting/stopping detection and adjusting threshold
- rename texture view and update layout to include new controls

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_b_6841aa82986c832a8c3c9febf83d07a6